### PR TITLE
Reconocimiento de acentos y ñ

### DIFF
--- a/ucbcba.cls
+++ b/ucbcba.cls
@@ -28,6 +28,7 @@
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{book}}
 \ProcessOptions\relax
 \LoadClass[12pt,oneside]{book}
+\usepackage[utf8]{inputenc}
 
 
 \RequirePackage[top=3cm, left=3.5cm, bottom=3cm, right=3cm, paper=letterpaper]{geometry} %%Margenes


### PR DESCRIPTION
Con esto se podrá escribir el texto tranquilamente, puede existir conflicto para quien no use Unicode utf-8, pero con esto se soluciona el tener que poner \' para acentuar